### PR TITLE
migration locations option relative path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you want to use a JSON file, please use the following.
         }
     },
     "migration": {
-        "locations": ["~/migration"],
+        "locations": ["/migration"],
         "baselineVersion": "v1.0.0"
     }
 }
@@ -78,7 +78,7 @@ If you want to use a JSON file, please use the following.
 * elasticsearch.connect.cloudId : Enter your Elasticsearch Cloud ID.
 * elasticsearch.connect.username : Enter your Elasticsearch username.
 * elasticsearch.connect.password : Enter your Elasticsearch password.
-* migration.locations : Enter the full path to the directory where you want to store your migration script.
+* migration.locations : Enter the full path or relative path to the directory where you want to store your migration script
 * migration.baselineVersion : Please fill in the base version of the migration script
 
 To set the environment variables, set the following variables.

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -7,7 +7,7 @@ export const indexNameRegexp = /[-_]/;
 export const fileNameRegexp = /^([v][0-9]+.[0-9]+.[0-9]+)__([0-9a-zA-Z]+)/;
 
 export function findFiles(dir: string, callback?: (data: string) => void) {
-    const filenames = fs.readdirSync(dir);
+    const filenames = fs.readdirSync(path.relative(process.cwd(), dir));
     filenames.forEach((filename) => {
         const fullPath = path.join(dir, filename);
         const stats = fs.statSync(fullPath);


### PR DESCRIPTION
hi
The document was wrong.
unsupported bash home(~)

and

supported relative path 
