### PR TITLE
fix mocha v6 -> v7

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,8 @@
+{
+  "require": [
+    "ts-node/register"
+  ],
+  "recursive": true,
+  "reporter": "spec",
+  "timeout": "10000"
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,0 @@
---require ts-node/register
---watch-extensions ts
---recursive
---reporter spec
---timeout 10000


### PR DESCRIPTION
It is a result message of execution `yarn test`
```
(node:65474) DeprecationWarning: Configuration via mocha.opts is DEPRECATED and will be removed from a future version of Mocha. Use RC files or package.json instead.
```

deprecated mocha.opts
So rewrite `.mocharc.[json|js|yml]`
